### PR TITLE
Bump up using mysql source version to 5.6.40

### DIFF
--- a/ansible/files/home/packages/bin/create-snapshot-package.sh
+++ b/ansible/files/home/packages/bin/create-snapshot-package.sh
@@ -13,7 +13,7 @@ run()
 }
 
 keep_n_days=7
-mysql_version=5.6.21
+mysql_version=5.6.40
 
 today=$(date +%Y.%m.%d)
 mysql_base="mysql-${mysql_version}"


### PR DESCRIPTION
5.6.29 had been deleted in jaist mirror.