### PR TITLE
Add support almalinux for mecab-devel package

### DIFF
--- a/mecab/Rakefile
+++ b/mecab/Rakefile
@@ -7,7 +7,7 @@ class MecabPackageTask < PackagesGroongaOrgPackageTask
 
   private
   def define_archive_task
-    dist = ".module_el8.2.0+493+63b41e36"
+    dist = ".module_el8.4.0+2532+b8928c02"
     release = "9"
     srpm_name = "#{@rpm_package}-#{@version}-#{@rpm_release}#{dist}.#{release}.src.rpm"
 

--- a/mecab/yum/almalinux-8/Dockerfile
+++ b/mecab/yum/almalinux-8/Dockerfile
@@ -1,0 +1,19 @@
+ARG FROM=almalinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} \
+    gcc-c++ \
+    make \
+    rpm-build \
+    rpmdevtools && \
+  dnf clean ${quiet} all
+
+RUN \
+  sed \
+    -i'' \
+    -e 's/^%dist .*/%dist .module_el8.3.0+2049+47abd494/' \
+    /etc/rpm/macros.dist


### PR DESCRIPTION
We also update mecab-devel version.
The latest version of mecab for AlmaLinux 8 is `module_el8.4.0+2532+b8928c02`

See: http://ftp.iij.ad.jp/pub/linux/almalinux/8.4/AppStream/Source/Packages