### PR TITLE
Update mecab devel for centos8

### DIFF
--- a/mecab/Rakefile
+++ b/mecab/Rakefile
@@ -7,12 +7,12 @@ class MecabPackageTask < PackagesGroongaOrgPackageTask
 
   private
   def define_archive_task
-    dist = ".module_el8.4.0+2532+b8928c02"
+    dist = detect_srpm_dist
     release = "9"
     srpm_name = "#{@rpm_package}-#{@version}-#{@rpm_release}#{dist}.#{release}.src.rpm"
 
     file srpm_name do
-      base_url = "https://repo.almalinux.org/almalinux/8.4/AppStream/Source/Packages/"
+      base_url = detect_srpm_base_url
       download("#{base_url}/#{srpm_name}", srpm_name)
     end
 
@@ -30,8 +30,33 @@ class MecabPackageTask < PackagesGroongaOrgPackageTask
 
   def yum_targets_default
     [
-      "almalinux-8"
+      "almalinux-8",
+      "centos-8"
     ]
+  end
+
+  def detect_srpm_base_url
+    base_url = ""
+    yum_targets.each do |target|
+      if target == "almalinux-8"
+        base_url = "https://repo.almalinux.org/almalinux/8.4/AppStream/Source/Packages"
+      else
+        base_url = "https://vault.centos.org/8.5.2111/AppStream/Source/SPackages"
+      end
+    end
+    base_url
+  end
+
+  def detect_srpm_dist
+    dist = ""
+    yum_targets.each do |target|
+      if target == "almalinux-8"
+        dist = ".module_el8.4.0+2532+b8928c02"
+      else
+        dist = ".module_el8.4.0+589+11e12751"
+      end
+    end
+    dist
   end
 end
 

--- a/mecab/yum/centos-8/Dockerfile
+++ b/mecab/yum/centos-8/Dockerfile
@@ -1,0 +1,19 @@
+ARG FROM=centos:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install --enablerepo=powertools -y ${quiet} \
+    gcc-c++ \
+    make \
+    rpm-build \
+    rpmdevtools && \
+  dnf clean ${quiet} all
+
+RUN \
+  sed \
+    -i'' \
+    -e 's/^%dist .*/%dist .module_el8.4.0+589+11e12751/' \
+    /etc/rpm/macros.dist


### PR DESCRIPTION
Because mecab package updated to https://vault.centos.org/8.5.2111/AppStream/Source/SPackages/mecab-0.996-1.module_el8.4.0+589+11e12751.9.src.rpm in the latest version of CentOS 8.

I can build the package with this PR on my environment as below.

```
% tree .
.
├── Rakefile
├── mecab-0.996-1.module_el8.4.0+589+11e12751.9.src.rpm
├── mecab-0.996.tar.gz
└── yum
    ├── almalinux-8
    │   └── Dockerfile
    ├── build.sh
    ├── centos-8
    │   └── Dockerfile
    ├── env.sh
    ├── mecab.spec.in
    ├── repositories
    │   ├── almalinux
    │   │   └── 8
    │   │       ├── source
    │   │       │   └── SRPMS
    │   │       │       └── mecab-0.996-1.module_el8.4.0+2532+b8928c02.9.src.rpm
    │   │       └── x86_64
    │   │           └── Packages
    │   │               ├── mecab-0.996-1.module_el8.4.0+2532+b8928c02.9.x86_64.rpm
    │   │               ├── mecab-debuginfo-0.996-1.module_el8.4.0+2532+b8928c02.9.x86_64.rpm
    │   │               ├── mecab-debugsource-0.996-1.module_el8.4.0+2532+b8928c02.9.x86_64.rpm
    │   │               └── mecab-devel-0.996-1.module_el8.4.0+2532+b8928c02.9.x86_64.rpm
    │   └── centos
    │       └── 8
    │           ├── source
    │           │   └── SRPMS
    │           │       └── mecab-0.996-1.module_el8.4.0+589+11e12751.9.src.rpm
    │           └── x86_64
    │               └── Packages
    │                   ├── mecab-0.996-1.module_el8.4.0+589+11e12751.9.x86_64.rpm
    │                   ├── mecab-debuginfo-0.996-1.module_el8.4.0+589+11e12751.9.x86_64.rpm
    │                   ├── mecab-debugsource-0.996-1.module_el8.4.0+589+11e12751.9.x86_64.rpm
    │                   └── mecab-devel-0.996-1.module_el8.4.0+589+11e12751.9.x86_64.rpm
    └── tmp
        ├── mecab-0.996.tar.gz
        └── mecab.spec
```