### PR TITLE
Install apt-dists-merge explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org/"
 
 gem "rake"
+gem "apt-dists-merge"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 
 source "https://rubygems.org/"
 
-gem "rake"
 gem "apt-dists-merge"
+gem "rake"


### PR DESCRIPTION
Without this fix, it causes the following LoadError:

  % rake -T
  rake aborted!
  LoadError: cannot load such file -- apt-dists-merge