### PR TITLE
groonga-release: add support for Oracle Linux 8

### DIFF
--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -63,7 +63,7 @@ class GroongaReleasePackageTask < PackagesGroongaOrgPackageTask
         label: "Oracle Linux $releasever",
         distribution: "oracle-linux",
         version: "$releasever",
-        enabled: "1",
+        enabled: "0",
       },
     ]
     targets.each do |target|

--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -58,6 +58,13 @@ class GroongaReleasePackageTask < PackagesGroongaOrgPackageTask
         version: "$releasever",
         enabled: "0",
       },
+      {
+        id: "oracle-linux",
+        label: "Oracle Linux $releasever",
+        distribution: "oracle-linux",
+        version: "$releasever",
+        enabled: "1",
+      },
     ]
     targets.each do |target|
       repo_path = "#{@archive_base_name}/#{repository_name}-#{target[:id]}.repo"
@@ -101,6 +108,7 @@ enabled=#{target[:enabled]}
       "almalinux-9",
       "amazon-linux-2",
       "centos-7",
+      "oracle-linux-8",
     ]
   end
 

--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -76,6 +76,9 @@ else
 fi
 
 %changelog
+* Wed Feb 1 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.1-1
+- Add support for Oracle Linux 8.
+
 * Sun Mar 6 2022 Sutou Kouhei <kou@clear-code.com> - 2022.3.6-1
 - Split Amazon Linux 2 repository.
 

--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -57,14 +57,22 @@ if grep -q 'Amazon Linux' /etc/os-release 2>/dev/null; then
   %{disable_repository groonga-almalinux}
   %{enable_repository groonga-amazon-linux}
   %{disable_repository groonga-centos}
+  %{disable_repository groonga-oracle-linux}
 elif grep -q 'CentOS' /etc/os-release 2>/dev/null; then
   %{disable_repository groonga-almalinux}
   %{disable_repository groonga-amazon-linux}
   %{enable_repository groonga-centos}
+  %{disable_repository groonga-oracle-linux}
+elif grep -q 'Oracle Linux' /etc/os-release 2>/dev/null; then
+  %{disable_repository groonga-almalinux}
+  %{disable_repository groonga-amazon-linux}
+  %{disable_repository groonga-centos}
+  %{enable_repository groonga-oracle-linux}
 else
   %{enable_repository groonga-almalinux}
   %{disable_repository groonga-amazon-linux}
   %{disable_repository groonga-centos}
+  %{disable_repository groonga-oracle-linux}
 fi
 
 %changelog

--- a/groonga-release/yum/oracle-linux-8/Dockerfile
+++ b/groonga-release/yum/oracle-linux-8/Dockerfile
@@ -1,0 +1,10 @@
+FROM oraclelinux:8
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  dnf install -y ${quiet} \
+    rpm-build && \
+  dnf clean ${quiet} all


### PR DESCRIPTION
We will provide package for Oracle Linux 8.
Mroonga for AlmaLinux 8 required mysql-community-server. However, MySQL official Docker image uses mysql-community-server-minimal.

Therefore, Mroonga for AlamLinux 8 doesn't install on MySQL official Docker image in default.
Therefore, We need to create Mroonga package for Oracle Linux 8.