### PR TITLE
groonga-release: add support for Oracle Linux 9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,8 @@ class GroongaRepositoryTask < RepositoryTask
       ["almalinux", "8"],
       ["amazon-linux", "2"],
       ["centos", "7"],
-      ["oracle-linux", "8"],
       ["oracle-linux", "9"],
+      ["oracle-linux", "8"],
     ]
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,7 @@ class GroongaRepositoryTask < RepositoryTask
       ["amazon-linux", "2"],
       ["centos", "7"],
       ["oracle-linux", "8"],
+      ["oracle-linux", "9"],
     ]
   end
 end

--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -109,6 +109,7 @@ enabled=#{target[:enabled]}
       "amazon-linux-2",
       "centos-7",
       "oracle-linux-8",
+      "oracle-linux-9",
     ]
   end
 

--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -77,10 +77,7 @@ fi
 
 %changelog
 * Wed Feb 2 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.2-1
-- Add support for Oracle Linux 9.
-
-* Wed Feb 1 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.1-1
-- Add support for Oracle Linux 8.
+- Add support for Oracle Linux 8 and Oracle Linux 9.
 
 * Sun Mar 6 2022 Sutou Kouhei <kou@clear-code.com> - 2022.3.6-1
 - Split Amazon Linux 2 repository.

--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -76,6 +76,9 @@ else
 fi
 
 %changelog
+* Wed Feb 2 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.2-1
+- Add support for Oracle Linux 9.
+
 * Wed Feb 1 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.1-1
 - Add support for Oracle Linux 8.
 

--- a/groonga-release/yum/oracle-linux-9/Dockerfile
+++ b/groonga-release/yum/oracle-linux-9/Dockerfile
@@ -1,0 +1,10 @@
+FROM oraclelinux:9
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  dnf install -y ${quiet} \
+    rpm-build && \
+  dnf clean ${quiet} all

--- a/helper.rb
+++ b/helper.rb
@@ -1,7 +1,7 @@
 module Helper
   module RepositoryDetail
     def repository_version
-      "2023.2.1"
+      "2023.2.2"
     end
 
     def repository_name


### PR DESCRIPTION
We need to merge https://github.com/groonga/packages.groonga.org/pull/33 before merging this PR.