### PR TITLE
mecab: support Oracle Linux 8 and 9

### DIFF
--- a/mecab-oracle-linux-8/.gitignore
+++ b/mecab-oracle-linux-8/.gitignore
@@ -1,0 +1,2 @@
+/*.src.rpm
+/yum/*.spec.in

--- a/mecab-oracle-linux-8/Rakefile
+++ b/mecab-oracle-linux-8/Rakefile
@@ -1,0 +1,39 @@
+require_relative "../packages-groonga-org-package-task"
+
+class MecabPackageTask < PackagesGroongaOrgPackageTask
+  def initialize
+    super("mecab", "0.996", nil)
+  end
+
+  private
+  def define_archive_task
+    dist = ".module+el8.6.0+20849+f637f661"
+    @rpm_release = "2"
+    srpm_name = "#{@rpm_package}-#{@version}-#{@rpm_release}#{dist}.src.rpm"
+
+    file srpm_name do
+      base_url = "https://yum.oracle.com/repo/OracleLinux/OL8/appstream/x86_64/getPackageSource"
+      download("#{base_url}/#{srpm_name}", srpm_name)
+    end
+
+    [@archive_name, yum_spec_in_path].each do |source_file|
+      file source_file => srpm_name do
+        sh("rpm2cpio #{srpm_name} | cpio -id")
+        mv("#{@rpm_package}.spec", yum_spec_in_path)
+      end
+    end
+  end
+
+  def enable_apt?
+    false
+  end
+
+  def yum_targets_default
+    [
+      "oracle-linux-8",
+    ]
+  end
+end
+
+task = MecabPackageTask.new
+task.define

--- a/mecab-oracle-linux-8/yum/oracle-linux-8/Dockerfile
+++ b/mecab-oracle-linux-8/yum/oracle-linux-8/Dockerfile
@@ -1,0 +1,19 @@
+ARG FROM=oraclelinux:8
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} \
+    gcc-c++ \
+    make \
+    rpm-build \
+    rpmdevtools && \
+  dnf clean ${quiet} all
+
+RUN \
+  sed \
+    -i'' \
+    -e 's/^%dist .*/%dist .module+el8.6.0+20849+f637f661/' \
+    /etc/rpm/macros.dist

--- a/mecab-oracle-linux-9/.gitignore
+++ b/mecab-oracle-linux-9/.gitignore
@@ -1,0 +1,2 @@
+/*.src.rpm
+/yum/*.spec.in

--- a/mecab-oracle-linux-9/Rakefile
+++ b/mecab-oracle-linux-9/Rakefile
@@ -1,0 +1,40 @@
+require_relative "../packages-groonga-org-package-task"
+
+class MecabPackageTask < PackagesGroongaOrgPackageTask
+  def initialize
+    super("mecab", "0.996", nil)
+  end
+
+  private
+  def define_archive_task
+    dist = ".el9"
+    release = "3"
+    @rpm_release = "3"
+    srpm_name = "#{@rpm_package}-#{@version}-#{@rpm_release}#{dist}.#{release}.src.rpm"
+
+    file srpm_name do
+      base_url = "https://yum.oracle.com/repo/OracleLinux/OL9/appstream/x86_64/getPackageSource"
+      download("#{base_url}/#{srpm_name}", srpm_name)
+    end
+
+    [@archive_name, yum_spec_in_path].each do |source_file|
+      file source_file => srpm_name do
+        sh("rpm2cpio #{srpm_name} | cpio -id")
+        mv("#{@rpm_package}.spec", yum_spec_in_path)
+      end
+    end
+  end
+
+  def enable_apt?
+    false
+  end
+
+  def yum_targets_default
+    [
+      "oracle-linux-9",
+    ]
+  end
+end
+
+task = MecabPackageTask.new
+task.define

--- a/mecab-oracle-linux-9/yum/oracle-linux-9/Dockerfile
+++ b/mecab-oracle-linux-9/yum/oracle-linux-9/Dockerfile
@@ -1,0 +1,13 @@
+ARG FROM=oraclelinux:9
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} \
+    gcc-c++ \
+    make \
+    rpm-build \
+    rpmdevtools && \
+  dnf clean ${quiet} all


### PR DESCRIPTION
Because we need to mecab-devel for Oracle Linux 8 and 9 to build the package of Groonga.