### PR TITLE
groonga-apt-source: refresh Debian support

### DIFF
--- a/groonga-apt-source/Rakefile
+++ b/groonga-apt-source/Rakefile
@@ -35,8 +35,8 @@ class GroongaAptSourcePackageTask < PackagesGroongaOrgPackageTask
 
   def apt_targets_default
     [
-      "debian-buster",
       "debian-bullseye",
+      "debian-bookworm",
       "ubuntu-bionic",
       "ubuntu-focal",
       "ubuntu-impish",

--- a/groonga-apt-source/apt/debian-bookworm/Dockerfile
+++ b/groonga-apt-source/apt/debian-bookworm/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 RUN \
   echo "debconf debconf/frontend select Noninteractive" | \
@@ -13,5 +13,4 @@ RUN \
     debhelper \
     devscripts \
     gnupg && \
-  apt clean && \
-  rm -rf /var/lib/apt/lists/*
+  apt clean


### PR DESCRIPTION
* Drop support for Debian 10 (buster)
* Add support for Debian 12 (bookworm)