### PR TITLE
apache arrow: drop support for CentOS 7

### DIFF
--- a/apache-arrow/Rakefile
+++ b/apache-arrow/Rakefile
@@ -61,7 +61,6 @@ class ApacheArrowPackageTask < PackagesGroongaOrgPackageTask
   def yum_targets
     [
       "almalinux-8",
-      "centos-7",
     ]
   end
 


### PR DESCRIPTION
CentOS 7's EOL came. So Groonga stopped supporting a package for CentOS 7.

ref: https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/