### PR TITLE
apache arrow: update Apache Arrow to 17.0.0

### DIFF
--- a/apache-arrow/Rakefile
+++ b/apache-arrow/Rakefile
@@ -4,7 +4,7 @@ require_relative "../packages-groonga-org-package-task"
 
 class ApacheArrowPackageTask < PackagesGroongaOrgPackageTask
   def initialize
-    super("apache-arrow", "16.1.0", Time.new(2024, 5, 14))
+    super("apache-arrow", "17.0.0", Time.new(2024, 7, 16))
   end
 
   private


### PR DESCRIPTION
Apache Arrow 17.0.0 has released.

ref: https://arrow.apache.org/release/17.0.0.html