### PR TITLE
apache arrow: add why we mirror Apache Arrow packages

### DIFF
--- a/apache-arrow/README.md
+++ b/apache-arrow/README.md
@@ -1,7 +1,8 @@
-### Why We Mirror Apache Arrow
+### Why we mirror Apache Arrow
 
 Groonga depends on Apache Arrow.
 However, the official Apache Arrow repository has been unstable at times, causing issues for Groonga users.
+See also the Apache Arrow issue: https://github.com/apache/arrow/issues/40744
 To resolve this situation, we have been providing a mirrored version for Groonga users.
 
 #### Note

--- a/apache-arrow/README.md
+++ b/apache-arrow/README.md
@@ -7,7 +7,6 @@ Groonga depends on Apache Arrow. However, the official Apache Arrow repository h
 We would like to stop mirroring the Apache Arrow repository.
 Therefore, we intend to stop mirroring once the Apache Arrow repository is stable.
 
-
 ### How to version up
 
 1. Update Apache Arrow version and release data in Rakefile

--- a/apache-arrow/README.md
+++ b/apache-arrow/README.md
@@ -1,3 +1,11 @@
+### Why We Mirror Apache Arrow
+
+Groonga depends on Apache Arrow. However, the official Apache Arrow repository has been unstable at times, causing issues for Groonga users. To resolve this situation, we have been providing a mirrored version for Groonga users.
+
+Going forward, we plan to discontinue the mirror except in the following cases.
+- Packages that depend on the mirrored Apache Arrow (e.x. AlamaLinux 8).
+- When there are requests from specific Groonga users (such as Zulip).
+
 ### How to version up
 
 1. Update Apache Arrow version and release data in Rakefile

--- a/apache-arrow/README.md
+++ b/apache-arrow/README.md
@@ -1,6 +1,8 @@
 ### Why We Mirror Apache Arrow
 
-Groonga depends on Apache Arrow. However, the official Apache Arrow repository has been unstable at times, causing issues for Groonga users. To resolve this situation, we have been providing a mirrored version for Groonga users.
+Groonga depends on Apache Arrow.
+However, the official Apache Arrow repository has been unstable at times, causing issues for Groonga users.
+To resolve this situation, we have been providing a mirrored version for Groonga users.
 
 #### Note
 

--- a/apache-arrow/README.md
+++ b/apache-arrow/README.md
@@ -2,9 +2,11 @@
 
 Groonga depends on Apache Arrow. However, the official Apache Arrow repository has been unstable at times, causing issues for Groonga users. To resolve this situation, we have been providing a mirrored version for Groonga users.
 
-Going forward, we plan to discontinue the mirror except in the following cases.
-- Packages that depend on the mirrored Apache Arrow (e.x. AlamaLinux 8).
-- When there are requests from specific Groonga users (such as Zulip).
+#### Note
+
+We would like to stop mirroring the Apache Arrow repository.
+Therefore, we intend to stop mirroring once the Apache Arrow repository is stable.
+
 
 ### How to version up
 


### PR DESCRIPTION
We added the explanation about why we mirror Apache Arrow.
This context will help Groonga's maintainers to handle how to mirror Apache Arrow.