### PR TITLE
apache arrow: drop support for Debian bullseye

### DIFF
--- a/apache-arrow/Rakefile
+++ b/apache-arrow/Rakefile
@@ -36,7 +36,6 @@ class ApacheArrowPackageTask < PackagesGroongaOrgPackageTask
       # for Zulip. Zulip uses packages.groonga.org temporary when the
       # official Apache Arrow APT repository was down.
       "debian-bookworm",
-      "debian-bullseye",
       "ubuntu-focal",
     ]
   end


### PR DESCRIPTION
Debian bullseye have already reached EOL.