### PR TITLE
deploy webhook: add support for `groonga-nginx`

### DIFF
--- a/ansible/files/home/packages/webhook/lib/deployer/app.rb
+++ b/ansible/files/home/packages/webhook/lib/deployer/app.rb
@@ -110,6 +110,8 @@ module Deployer
       case [env["GITHUB_OWNER"], env["GITHUB_REPOSITORY"]]
       when ["groonga", "groonga"]
         env["PACKAGE"] = "groonga"
+      when ["groonga", "groonga-nginx"]
+        env["PACKAGE"] = "groonga-nginx"
       when ["groonga", "groonga-normalizer-mysql"]
         env["PACKAGE"] = "groonga-normalizer-mysql"
       when ["mroonga", "mroonga"]


### PR DESCRIPTION
This PR is a part of automatically releasing signed packages.
- Add groonga-nginx's release flow to the deploy webhook in packages.groonga.org.
  - Using release event triggers the webhook