### PR TITLE
deploy webhook: remove `workflow_run` event handling

### DIFF
--- a/ansible/files/home/packages/webhook/lib/deployer/app.rb
+++ b/ansible/files/home/packages/webhook/lib/deployer/app.rb
@@ -91,7 +91,7 @@ module Deployer
       case payload.event_name
       when "ping"
         # Do nothing because this is a kind of healthcheck.
-      when "release", "workflow_run"
+      when "release"
         return unless payload.released?
         deploy(payload)
       else


### PR DESCRIPTION
GitHub: https://github.com/groonga/groonga/pull/2234

In our release workflow, we no longer use the
`workflow_run` event. Instead, we rely on the `release` event which is aligning our process with related
projects such as PGroonga and Mroonga.

This change removes all logic related to `workflow_run` events, simplifying the deployment process.