### PR TITLE
remove vendor/groonga submodule and specify Groonga repository

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,13 @@
 # -*- ruby -*-
 
 require_relative "helper"
-require_relative "vendor/groonga/packages/repository-helper"
 require_relative "vendor/packages.red-data-tools.org/repository-task"
+
+groonga_repository = ENV["GROONGA_REPOSITORY"]
+if groonga_repository.nil?
+  raise "Specify GROONGA_REPOSITORY environment variable"
+end
+require "#{groonga_repository}/packages/repository-helper"
 
 user = ENV["ANSIBLE_GPG_USER"] || ENV["USER"]
 file "ansible/password" => "ansible/password.#{user}.asc" do |task|

--- a/packages-groonga-org-package-task.rb
+++ b/packages-groonga-org-package-task.rb
@@ -1,5 +1,10 @@
 require_relative "helper"
-require_relative "vendor/groonga/packages/packages-groonga-org-package-task"
+
+groonga_repository = ENV["GROONGA_REPOSITORY"]
+if groonga_repository.nil?
+  raise "Specify GROONGA_REPOSITORY environment variable"
+end
+require "#{groonga_repository}/packages/packages-groonga-org-package-task"
 
 class PackagesGroongaOrgPackageTask
   include Helper::RepositoryDetail


### PR DESCRIPTION
Managing Groonga as a submodule prevented us from easily using the latest Groonga package code.
This change removes the vendor/groonga submodule and updates our build tasks.
Groonga’s helper scripts and package tasks are loaded from a repository specified by the `GROONGA_REPOSITORY` environment variable.