### PR TITLE
groonga-apt-source: support for Ubuntu packages in Launchpad

### DIFF
--- a/groonga-apt-source/Rakefile
+++ b/groonga-apt-source/Rakefile
@@ -115,10 +115,6 @@ class GroongaAptSourcePackageTask < PackagesGroongaOrgPackageTask
     end
   end
 
-  def enable_ubuntu?
-    false
-  end
-
   def enable_yum?
     false
   end


### PR DESCRIPTION
Until now, groonga-apt-source packages were not provided via Launchpad.
We plan to migrate from the Launchpad PPA (ppa:groonga/ppa) to the Groonga APT repository (packages.groonga.org) due to certain limitations like we cannot use Groonga built with Apache Arrow enabled

This change enables support for groonga-apt-source packages on Ubuntu.
With this update, Launchpad users can easily register the Groonga APT repository and start using it.