### PR TITLE
groonga-apt-source: use detect_release_time in PackagesGroongaOrgPackageTask

### DIFF
--- a/groonga-apt-source/Rakefile
+++ b/groonga-apt-source/Rakefile
@@ -6,7 +6,7 @@ class GroongaAptSourcePackageTask < PackagesGroongaOrgPackageTask
   def initialize
     super("groonga-apt-source",
           repository_version,
-          latest_commit_time(File.join(__dir__, "..")))
+          detect_release_time)
   end
 
   def define


### PR DESCRIPTION
## Problem

Running `rake ubuntu` command raised the following
error because we don't include `Helper::ApacheArrow` which provides `latest_commit_time`.

```console
$ rake ubuntu
rake aborted!
NoMethodError: undefined method 'latest_commit_time' for an instance of GroongaAptSourcePackageTask (NoMethodError)

          latest_commit_time(File.join(__dir__, "..")))
          ^^^^^^^^^^^^^^^^^^
/home/otegami/work/ruby/packages.groonga.org/groonga-apt-source/Rakefile:9:in 'GroongaAptSourcePackageTask#initialize'
/home/otegami/work/ruby/packages.groonga.org/groonga-apt-source/Rakefile:123:in 'Class#new'
/home/otegami/work/ruby/packages.groonga.org/groonga-apt-source/Rakefile:123:in '<top (required)>'
(See full trace by running task with --trace)
```

## Solution

Instead of using `latest_commit_time`, we now use
`detect_release_time` to get the release date, similar to how Groonga does it.
And also, we don't have to use the additional module dependency.