### PR TITLE
groonga-apt-source: define missed github_repository for building apt packages

### DIFF
--- a/groonga-apt-source/Rakefile
+++ b/groonga-apt-source/Rakefile
@@ -118,6 +118,10 @@ class GroongaAptSourcePackageTask < PackagesGroongaOrgPackageTask
   def enable_yum?
     false
   end
+
+  def github_repository
+    "groonga/packages.groonga.org"
+  end
 end
 
 task = GroongaAptSourcePackageTask.new


### PR DESCRIPTION
Running `rake apt:build` failed as follows because the `github_repository` method was not defined in
`GroongaAptSourcePackageTask`.

By defining `github_repository`, the apt build process can now complete successfully.

```console
rake apt:build
rm -rf apt/tmp
mkdir -p apt/tmp
cp groonga-apt-source-2024.12.31.tar.gz apt/tmp/groonga-apt-source-2024.12.31.tar.gz
cp -r debian apt/tmp/debian.debian-bookworm
cp -r debian apt/tmp/debian.debian-trixie
cp -r debian apt/tmp/debian.ubuntu-jammy
cp -r debian apt/tmp/debian.ubuntu-noble
cd apt
rake aborted!
NotImplementedError: NotImplementedError (NotImplementedError)
/home/otegami/work/c/groonga/packages/packages-groonga-org-package-task.rb:136:in 'PackagesGroongaOrgPackageTask#github_repository'
/home/otegami/work/c/groonga/packages/packages-groonga-org-package-task.rb:128:in 'PackagesGroongaOrgPackageTask#docker_image'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:119:in 'PackageTask#docker_run'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:349:in 'block (2 levels) in PackageTask#apt_build'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:346:in 'block in PackageTask#apt_build'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:345:in 'Array#each'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:345:in 'PackageTask#apt_build'
/home/otegami/work/cpp/arrow/dev/tasks/linux-packages/package-task.rb:377:in 'block (2 levels) in PackageTask#define_apt_task'
Tasks: TOP => apt:build
(See full trace by running task with --trace)
```