### PR TITLE
groonga-apt-source: don't require home directory

### DIFF
--- a/groonga-apt-source/debian/rules
+++ b/groonga-apt-source/debian/rules
@@ -5,20 +5,18 @@
 #export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
-export GROONGA_HOME := $(shell mktemp -d)
+export GNUPGHOME := $(shell mktemp -d)
 
 %:
 	dh $@
 
 override_dh_auto_build:
-	mkdir -p $(GROONGA_HOME)/.gnupg
+	mkdir -p $(GNUPGHOME)/.gnupg
 	gpg \
-	  --homedir $(GROONGA_HOME) \
 	  --no-default-keyring \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --import keys
 	gpg \
-	  --homedir $(GROONGA_HOME) \
 	  --no-default-keyring \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --export \

--- a/groonga-apt-source/debian/rules
+++ b/groonga-apt-source/debian/rules
@@ -5,19 +5,22 @@
 #export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
-export GNUPGHOME := $(shell mktemp -d)
 
 %:
 	dh $@
 
 override_dh_auto_build:
-	mkdir -p $(GNUPGHOME)/.gnupg
 	gpg \
+	  --no-autostart \
 	  --no-default-keyring \
+	  --no-options \
+	  --lock-never \
+	  --trustdb-name ./groonga-key-database \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --import keys
 	gpg \
 	  --no-default-keyring \
+	  --no-options \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --export \
 	  --armor > groonga-archive-keyring.asc

--- a/groonga-apt-source/debian/rules
+++ b/groonga-apt-source/debian/rules
@@ -5,16 +5,20 @@
 #export DH_VERBOSE=1
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
+export GROONGA_HOME := $(shell mktemp -d)
 
 %:
 	dh $@
 
 override_dh_auto_build:
+	mkdir -p $(GROONGA_HOME)/.gnupg
 	gpg \
+	  --homedir $(GROONGA_HOME) \
 	  --no-default-keyring \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --import keys
 	gpg \
+	  --homedir $(GROONGA_HOME) \
 	  --no-default-keyring \
 	  --keyring ./groonga-archive-keyring.kbx \
 	  --export \


### PR DESCRIPTION
## Problem

In Launchpad builds, building groonga-apt-source package failed as follows.

```
dpkg-buildpackage
-----------------

Command: dpkg-buildpackage --sanitize-env -us -uc -mLaunchpad Build Daemon <buildd@lcy02-amd64-094.buildd> -b -rfakeroot
dpkg-buildpackage: info: source package groonga-apt-source
dpkg-buildpackage: info: source version 2024.12.31-1.ubuntu22.04.1
dpkg-buildpackage: info: source distribution jammy
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 fakeroot debian/rules clean
dh clean
   dh_clean
 debian/rules build
dh build
   dh_update_autotools_config
   dh_autoreconf
   debian/rules override_dh_auto_build
make[1]: Entering directory '/<<PKGBUILDDIR>>'
gpg \
  --no-default-keyring \
  --keyring ./groonga-archive-keyring.kbx \
  --import keys
gpg: keybox './groonga-archive-keyring.kbx' created
gpg: Fatal: can't create directory '/sbuild-nonexistent/.gnupg': No such file or directory
make[1]: *** [debian/rules:13: override_dh_auto_build] Error 2
make[1]: Leaving directory '/<<PKGBUILDDIR>>'
make: *** [debian/rules:10: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

## Cause

The home directory (/sbuild-nonexistent) doesn't exist on Launchpad.
GnuPG still attempts to reference or create the .gnupg directory under home directory.
So it leads to this problem.

## Solution

Since our use case does not require a home directory,
we configure GnuPG to avoid using the default settings.

- Specifying --no-options to skip loading configuration files.
- Setting --no-autostart and --lock-never to prevent automatic behaviors that might require a home directory.
- Specifying a trust database file (using --trustdb-name ./groonga-key-database). If not,  it requires a home directory.

These combination allows GnuPG to operate solely on the provided files without attempting to access or create files in ~/.gnupg.

## Why we chose this way

The default home directory (/sbuild-nonexistent) in the build environment does not allow us to create .gnupg directory.
It causes an error with a "Permission denied" message. So we chose the above way.