### PR TITLE
groonga-release: use detect_release_time instead of latest_commit_time

### DIFF
--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -6,7 +6,7 @@ class GroongaReleasePackageTask < PackagesGroongaOrgPackageTask
   def initialize
     super("groonga-release",
           repository_version,
-          latest_commit_time(File.join(__dir__, "..")))
+          detect_release_time)
   end
 
   def define


### PR DESCRIPTION
This is a same issue of GH-57.
If we execute `rake yum` command, it raised the following error. because we don't include `Helper::ApacheArrow` which provides `latest_commit_time`.

```
rake aborted!
NoMethodError: undefined method 'latest_commit_time' for an instance of GroongaReleasePackageTask (NoMethodError)

          latest_commit_time(File.join(__dir__, "..")))
          ^^^^^^^^^^^^^^^^^^
/home/horimoto/Work/free-software/packages.groonga.org.fork/groonga-release/Rakefile:9:in 'GroongaReleasePackageTask#initialize'
/home/horimoto/Work/free-software/packages.groonga.org.fork/groonga-release/Rakefile:150:in 'Class#new'
/home/horimoto/Work/free-software/packages.groonga.org.fork/groonga-release/Rakefile:150:in '<top (required)>'
/home/horimoto/Work/free-software/packages.groonga.org.fork/vendor/bundle/ruby/3.4.0/gems/rake-13.3.0/exe/rake:27:in '<top (required)>'
/home/horimoto/.rbenv/versions/3.4.4/bin/bundle:25:in 'Kernel#load'
/home/horimoto/.rbenv/versions/3.4.4/bin/bundle:25:in '<main>'
(See full trace by running task with --trace)
```

So, instead of using `latest_commit_time`, we now use `detect_release_time` to get the release date, similar to how Groonga does it. And also, we don't have to use the additional module dependency.