### PR TITLE
groonga-release: add a missing "github_repository"

### DIFF
--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -144,6 +144,10 @@ enabled=#{target[:enabled]}
       task :release => :latest
     end
   end
+
+  def github_repository
+    "groonga/packages.groonga.org"
+  end
 end
 
 task = GroongaReleasePackageTask.new


### PR DESCRIPTION
If we don't definition github_repository, it raised the following error.

```
% bundle exec rake yum:build
rm -rf yum/tmp
mkdir -p yum/tmp
cp groonga-release-2025.06.26.tar.gz yum/tmp/groonga-release-2025.06.26.tar.gz
cd yum
rake aborted!
NotImplementedError: NotImplementedError (NotImplementedError)
/Work/free-software/groonga.clean/packages/packages-groonga-org-package-task.rb:137:in 'PackagesGroongaOrgPackageTask#github_repository'
/Work/free-software/groonga.clean/packages/packages-groonga-org-package-task.rb:128:in 'PackagesGroongaOrgPackageTask#docker_image'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:119:in 'PackageTask#docker_run'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:490:in 'block (2 levels) in PackageTask#yum_build'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:487:in 'block in PackageTask#yum_build'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:486:in 'Array#each'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:486:in 'PackageTask#yum_build'
/Work/free-software/arrow/dev/tasks/linux-packages/package-task.rb:517:in 'block (2 levels) in PackageTask#define_yum_task'
/Work/free-software/packages.groonga.org.fork/vendor/bundle/ruby/3.4.0/gems/rake-13.3.0/exe/rake:27:in '<top (required)>'
/.rbenv/versions/3.4.4/bin/bundle:25:in 'Kernel#load'
/.rbenv/versions/3.4.4/bin/bundle:25:in '<main>'
Tasks: TOP => yum:build
(See full trace by running task with --trace)
```

Because responsibility of the implementation of github_repository is destination of inheritance. related commit is https://github.com/groonga/groonga/commit/9eaa74d70b53a26b044bc3c38bcedce63ea3a142.

The value of github_repository is used for tag name of docket images as below.

```
docker build --cache-from ghcr.io/groonga/packages.groonga.org-package:groonga-release-almalinux-8 --tag ghcr.io/groonga/packages.groonga.org-package:groonga-release-almalinux-8 --build-arg DEBUG=yes almalinux-8
```