### PR TITLE
groonga-release: add support for AlmaLinux 10

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,7 @@ class GroongaRepositoryTask < RepositoryTask
 
   def yum_targets
     [
+      ["almalinux", "10"],
       ["almalinux", "9"],
       ["almalinux", "8"],
       ["amazon-linux", "2023"],

--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -92,6 +92,7 @@ enabled=#{target[:enabled]}
     [
       "almalinux-8",
       "almalinux-9",
+      "almalinux-10",
       "amazon-linux-2023",
     ]
   end

--- a/groonga-release/yum/almalinux-10/Dockerfile
+++ b/groonga-release/yum/almalinux-10/Dockerfile
@@ -1,0 +1,10 @@
+FROM almalinux:10
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  dnf install -y ${quiet} \
+    rpm-build && \
+  dnf clean ${quiet} all

--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -55,6 +55,9 @@ else
 fi
 
 %changelog
+* Thu Jun 26 2025 Horimoto Yasuhiro <horimoto@clear-code.com> - 2025.6.26-1
+- Add support for AlmaLinux 10.
+
 * Wed Feb 2 2023 Horimoto Yasuhiro <horimoto@clear-code.com> - 2023.2.2-1
 - Add support for Oracle Linux 8 and Oracle Linux 9.
 

--- a/helper.rb
+++ b/helper.rb
@@ -1,7 +1,7 @@
 module Helper
   module RepositoryDetail
     def repository_version
-      "2024.12.31"
+      "2025.06.26"
     end
 
     def repository_name


### PR DESCRIPTION
TODO: Test.

---

The result of rake yum:build.

```
yum/repositories
├── almalinux
│   ├── 10
│   │   ├── source
│   │   │   └── SRPMS
│   │   │       └── groonga-release-2025.06.26-1.src.rpm
│   │   └── x86_64
│   │       └── Packages
│   │           └── groonga-release-2025.06.26-1.noarch.rpm
│   ├── 8
│   │   ├── source
│   │   │   └── SRPMS
│   │   │       └── groonga-release-2025.06.26-1.src.rpm
│   │   └── x86_64
│   │       └── Packages
│   │           └── groonga-release-2025.06.26-1.noarch.rpm
│   └── 9
│       ├── source
│       │   └── SRPMS
│       │       └── groonga-release-2025.06.26-1.src.rpm
│       └── x86_64
│           └── Packages
│               └── groonga-release-2025.06.26-1.noarch.rpm
└── amazon-linux
    └── 2023
        ├── source
        │   └── SRPMS
        │       └── groonga-release-2025.06.26-1.src.rpm
        └── x86_64
            └── Packages
                └── groonga-release-2025.06.26-1.noarch.rpm
```