### PR TITLE
groonga-release: Exclude low strength GPG key

### DIFF
--- a/groonga-release/Rakefile
+++ b/groonga-release/Rakefile
@@ -23,6 +23,13 @@ class GroongaReleasePackageTask < PackagesGroongaOrgPackageTask
     "RPM-GPG-KEY-#{shorten_gpg_key_id(id).downcase}"
   end
 
+  def repository_gpg_key_ids
+    super.select do |gpg_key_id|
+      # This GPG key has low strength, so we will no longer use it.
+      gpg_key_id != "C97E4649A2051D0CEA1A73F972A7496B45499429"
+    end
+  end
+
   def generate_gpg_keys
     repository_gpg_key_ids.each do |gpg_key_id|
       path = "#{@archive_base_name}/#{rpm_gpg_key_path(gpg_key_id)}"


### PR DESCRIPTION
Since there is a better key, import it.

We have checked that C97E4649A2051D0CEA1A73F972A7496B45499429 is not required.
We checked with some old packages.

https://packages.groonga.org/almalinux/8/x86_64/Packages/

```
$ rpm -q gpg-pubkey --qf "%{name}-%{version}\t%{summary}\n"
gpg-pubkey-c2a1e572	AlmaLinux OS 10 <packager@almalinux.org> public key
gpg-pubkey-34839225	Groonga Key (Groonga Official Signing Key) <packages@groonga.org> public key

$ ls -1 *.rpm
groonga-11.0.9-1.el8.x86_64.rpm
mariadb-10.3-mroonga-11.11-1.el8.x86_64.rpm
mysql-community-8.0-mroonga-debuginfo-11.10-1.el8.x86_64.rpm
postgresql12-pgdg-pgroonga-2.3.4-1.el8.x86_64.rpm

$ for file in *.rpm; do rpm --checksig "${file}"; done
groonga-11.0.9-1.el8.x86_64.rpm: digests signatures OK
mariadb-10.3-mroonga-11.11-1.el8.x86_64.rpm: digests signatures OK
mysql-community-8.0-mroonga-debuginfo-11.10-1.el8.x86_64.rpm: digests signatures OK
postgresql12-pgdg-pgroonga-2.3.4-1.el8.x86_64.rpm: digests signatures OK
```