### PR TITLE
groonga-release: remove outdated GPG key for AlmaLinux10

### DIFF
--- a/groonga-release/yum/groonga-release.spec.in
+++ b/groonga-release/yum/groonga-release.spec.in
@@ -55,6 +55,9 @@ else
 fi
 
 %changelog
+* Thu Sep 25 2025 Kodama Takuya <otegami@clear-code.com> - 2025.9.25-1
+- Remove deprecated RPM GPG key from groonga-release.
+
 * Thu Jun 26 2025 Horimoto Yasuhiro <horimoto@clear-code.com> - 2025.6.26-1
 - Add support for AlmaLinux 10.
 

--- a/helper.rb
+++ b/helper.rb
@@ -1,7 +1,7 @@
 module Helper
   module RepositoryDetail
     def repository_version
-      "2025.06.26"
+      "2025.09.25"
     end
 
     def repository_name


### PR DESCRIPTION
GitHub: Fix GH-71
GitHub: ref https://github.com/groonga/groonga/pull/2528

## Summary

This PR updates groonga-release for AlmaLinux 10 to drop the outdated/low-strength RPM GPG key.
It also ships only the RSA4096 key. It resolves the following error about the `dnf` GPG check failure reported.

```console
# dnf install -y --enablerepo=epel --enablerepo=crb groonga
...
The Groonga Project for AlmaLinux 10 - x86_64                                                                          1.6 MB/s | 1.6 kB     00:00    
Importing GPG key 0x45499429:
 Userid     : ""
 Fingerprint: C97E 4649 A205 1D0C EA1A 73F9 72A7 496B 4549 9429
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-45499429
error: Certificate 72A7496B45499429:
  Policy rejects 72A7496B45499429: No binding signature at time 2025-09-24T09:35:25Z
Key import failed (code 2). Failing package is: groonga-15.1.5-1.el10.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-34839225, file:///etc/pki/rpm-gpg/RPM-GPG-KEY-45499429
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: GPG check FAILED
```

### What changed

We removed the deprecated key from the release package for AlmaLinux 10.
And also, we will keep only the RSA4096 key:

- /etc/pki/rpm-gpg/RPM-GPG-KEY-34839225

```console
$ rpm -ql groonga-release
/etc/pki/rpm-gpg
/etc/pki/rpm-gpg/RPM-GPG-KEY-34839225
/etc/yum.repos.d
/etc/yum.repos.d/groonga-almalinux.repo
/etc/yum.repos.d/groonga-amazon-linux.repo
```

## How to confirm

Using the new RPM GPG key, Groonga installs successfully on a fresh AlmaLinux 10 environment.

```console
$ dnf install -y --enablerepo=groonga-almalinux groonga
...
Importing GPG key 0x34839225:
 Userid     : "Groonga Key (Groonga Official Signing Key) <packages@groonga.org>"
 Fingerprint: 2701 F317 CFCC CB97 5CAD E9C2 624C F774 3483 9225
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-34839225
Key imported successfully
...
Installed:
  abseil-cpp-20240722.1-1.el10_0.x86_64 arrow2100-compute-libs-21.0.0-1.el10.x86_64 arrow2100-libs-21.0.0-1.el10.x86_64 groonga-15.1.5-1.el10.x86_64  
  groonga-libs-15.1.5-1.el10.x86_64     groonga-plugin-suggest-15.1.5-1.el10.x86_64 libicu-74.2-5.el10_0.x86_64         liborc2-2.0.3-1.el10_0.x86_64 
  lz4-1.9.4-8.el10.x86_64               msgpack-3.1.0-17.el10_0.x86_64              protobuf-3.19.6-11.el10.x86_64      re2-2:20250812-1.el10_0.x86_64
  snappy-1.1.10-7.el10.x86_64           utf8proc-2.7.0-9.el10.x86_64                xxhash-libs-0.8.3-1.el10_0.x86_64  

Complete!
```