### PR TITLE
groonga-apt-source: add support for ubuntu 26.04

### DIFF
--- a/groonga-apt-source/Rakefile
+++ b/groonga-apt-source/Rakefile
@@ -39,6 +39,7 @@ class GroongaAptSourcePackageTask < PackagesGroongaOrgPackageTask
       "debian-trixie",
       "ubuntu-jammy",
       "ubuntu-noble",
+      "ubuntu-resolute",
     ]
   end
 

--- a/groonga-apt-source/apt/ubuntu-resolute/Dockerfile
+++ b/groonga-apt-source/apt/ubuntu-resolute/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:resolute
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    debhelper \
+    devscripts \
+    gnupg && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/groonga-apt-source/debian/changelog
+++ b/groonga-apt-source/debian/changelog
@@ -1,3 +1,9 @@
+groonga-apt-source (2026.04.28-1) unstable; urgency=low
+
+  * Added support for Ubuntu 26.04 LTS.
+
+ -- Horimoto Yasuhiro <horimoto@clear-code.com>  Tue, 28 Apr 2026 00:38:09 -0000
+
 groonga-apt-source (2024.12.31-1) unstable; urgency=low
 
   * Use armored keyring.

--- a/helper.rb
+++ b/helper.rb
@@ -1,7 +1,7 @@
 module Helper
   module RepositoryDetail
     def repository_version
-      "2025.09.26"
+      "2026.04.28"
     end
 
     def repository_name


### PR DESCRIPTION
This change will generate the Ubuntu resolute directory as shown below.

```
% tree apt/repositories
apt/repositories
├── debian
│   └── pool
│       ├── bookworm
│       │   └── main
│       │       └── g
│       │           └── groonga-apt-source
│       │               ├── groonga-apt-source_2026.04.28-1.debian.tar.xz
│       │               ├── groonga-apt-source_2026.04.28-1.dsc
│       │               ├── groonga-apt-source_2026.04.28-1_all.deb
│       │               ├── groonga-apt-source_2026.04.28-1_amd64.buildinfo
│       │               ├── groonga-apt-source_2026.04.28-1_amd64.changes
│       │               └── groonga-apt-source_2026.04.28.orig.tar.gz
│       └── trixie
│           └── main
│               └── g
│                   └── groonga-apt-source
│                       ├── groonga-apt-source_2026.04.28-1.debian.tar.xz
│                       ├── groonga-apt-source_2026.04.28-1.dsc
│                       ├── groonga-apt-source_2026.04.28-1_all.deb
│                       ├── groonga-apt-source_2026.04.28-1_amd64.buildinfo
│                       ├── groonga-apt-source_2026.04.28-1_amd64.changes
│                       └── groonga-apt-source_2026.04.28.orig.tar.gz
└── ubuntu
    └── pool
        ├── jammy
        │   └── universe
        │       └── g
        │           └── groonga-apt-source
        │               ├── groonga-apt-source_2026.04.28-1.debian.tar.xz
        │               ├── groonga-apt-source_2026.04.28-1.dsc
        │               ├── groonga-apt-source_2026.04.28-1_all.deb
        │               ├── groonga-apt-source_2026.04.28-1_amd64.buildinfo
        │               ├── groonga-apt-source_2026.04.28-1_amd64.changes
        │               └── groonga-apt-source_2026.04.28.orig.tar.gz
        ├── noble
        │   └── universe
        │       └── g
        │           └── groonga-apt-source
        │               ├── groonga-apt-source_2026.04.28-1.debian.tar.xz
        │               ├── groonga-apt-source_2026.04.28-1.dsc
        │               ├── groonga-apt-source_2026.04.28-1_all.deb
        │               ├── groonga-apt-source_2026.04.28-1_amd64.buildinfo
        │               ├── groonga-apt-source_2026.04.28-1_amd64.changes
        │               └── groonga-apt-source_2026.04.28.orig.tar.gz
        └── resolute
            └── universe
                └── g
                    └── groonga-apt-source
                        ├── groonga-apt-source_2026.04.28-1.debian.tar.xz
                        ├── groonga-apt-source_2026.04.28-1.dsc
                        ├── groonga-apt-source_2026.04.28-1_all.deb
                        ├── groonga-apt-source_2026.04.28-1_amd64.buildinfo
                        ├── groonga-apt-source_2026.04.28-1_amd64.changes
                        └── groonga-apt-source_2026.04.28.orig.tar.gz

25 directories, 30 files
```