### PR TITLE
apache-arrow: update to 25.0.0

### DIFF
--- a/apache-arrow/Rakefile
+++ b/apache-arrow/Rakefile
@@ -4,7 +4,7 @@ require_relative "../packages-groonga-org-package-task"
 
 class ApacheArrowPackageTask < PackagesGroongaOrgPackageTask
   def initialize
-    super("apache-arrow", "24.0.0", Time.new(2026, 04, 21))
+    super("apache-arrow", "25.0.0", Time.new(2026, 07, 10))
     major, minor, patch = @version.split(".").collect(&:to_i)
     @so_version = ((major * 100) + minor).to_s
   end


### PR DESCRIPTION
Apache Arrow 25.0.0 was released on 2026-07-10.
See: https://arrow.apache.org/release/25.0.0.html